### PR TITLE
Refine AgentLogOntology with objects and actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # codex_testing
+
+This repository showcases **AgentLogOntology**, a flexible object/action data
+model for logging autonomous agent executions. The ontology distinguishes
+between persistent objects (agents, observations, actions, etc.) and the
+actions that mutate them. A parser demonstrates converting OpenAI
+``agent-traces`` JSON into ontology objects, and a simple Tkinter GUI lets you
+inspect and edit log state.
+
+## Usage
+
+1. Ensure Python with Tkinter is available.
+2. Run ``python demo.py`` to load ``sample_agent_trace.json`` and open the GUI.

--- a/agentlogontology/__init__.py
+++ b/agentlogontology/__init__.py
@@ -1,0 +1,26 @@
+"""AgentLogOntology package."""
+
+from .model import (
+    Action,
+    ActionKind,
+    AgentLog,
+    AgentRun,
+    Event,
+    ObjectKind,
+    OntologyObject,
+)
+from .parser import from_openai_trace
+from .serialization import log_to_dict, log_to_json
+
+__all__ = [
+    "Action",
+    "ActionKind",
+    "AgentLog",
+    "AgentRun",
+    "Event",
+    "ObjectKind",
+    "OntologyObject",
+    "from_openai_trace",
+    "log_to_dict",
+    "log_to_json",
+]

--- a/agentlogontology/model.py
+++ b/agentlogontology/model.py
@@ -1,0 +1,129 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+class ObjectKind(Enum):
+    """Enumerates high level ontology object types."""
+
+    AGENT = "Agent"
+    EVENT = "Event"
+    OBSERVATION_STREAM = "ObservationStream"
+    OBSERVATION = "Observation"
+    PRECEPT = "Precept"
+    ENVIRONMENT_CONTEXT = "EnvironmentContext"
+    THOUGHT = "Thought"
+    PLAN = "Plan"
+    POLICY = "Policy"
+    KNOWLEDGE_UNIT = "KnowledgeUnit"
+    STATE_VARIABLE = "StateVariable"
+    ACTION = "Action"
+    EXTERNAL_ACTION = "ExternalAction"
+    INTERNAL_ACTION = "InternalAction"
+    ACTION_RESULT = "ActionResult"
+    METRIC_SAMPLE = "MetricSample"
+    RISK_SIGNAL = "RiskSignal"
+    INTERVENTION_REQUEST = "InterventionRequest"
+    POLICY_RULE = "PolicyRule"
+    ANOMALY_DETECTOR = "AnomalyDetector"
+    ESCALATION_PATH = "EscalationPath"
+    HUMAN_FEEDBACK = "HumanFeedback"
+    EVAL_RUN = "EvalRun"
+    GOAL = "Goal"
+    TASK = "Task"
+    EPISODE = "Episode"
+    RUN = "Run"
+    MODEL_VERSION = "ModelVersion"
+    AGENT_VERSION = "AgentVersion"
+
+
+class ActionKind(Enum):
+    """Enumerates actions that operate on ontology objects."""
+
+    OBSERVE = "Observe"
+    INGEST = "Ingest"
+    PARSE = "Parse"
+    CONTEXTUALIZE = "Contextualize"
+    RETRIEVE = "Retrieve"
+    REASON = "Reason"
+    PLAN = "Plan"
+    SELECT_ACTION = "SelectAction"
+    EXECUTE = "Execute"
+    MUTATE_STATE = "MutateState"
+    WRITE_MEMORY = "WriteMemory"
+    ASSESS_OUTCOME = "AssessOutcome"
+    MEASURE_METRICS = "MeasureMetrics"
+    DETECT_ANOMALY = "DetectAnomaly"
+    FLAG_RISK = "FlagRisk"
+    REQUEST_INTERVENTION = "RequestIntervention"
+    ESCALATE = "Escalate"
+    INTERVENE = "Intervene"
+    APPROVE = "Approve"
+    REJECT = "Reject"
+    AMEND = "Amend"
+    EVALUATE = "Evaluate"
+    UPDATE_POLICY = "UpdatePolicy"
+    VERSION = "Version"
+    START_RUN = "StartRun"
+    COMPLETE_RUN = "CompleteRun"
+    REPLAY = "Replay"
+
+
+@dataclass
+class OntologyObject:
+    """Base type for all objects in the ontology."""
+
+    object_id: str
+    kind: ObjectKind
+    state: Dict[str, Any] = field(default_factory=dict)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Action:
+    """Represents an action performed on an object."""
+
+    action_id: str
+    kind: ActionKind
+    target: Optional[str] = None  # object_id of the action target
+    params: Dict[str, Any] = field(default_factory=dict)
+    result: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class Event:
+    """Envelope around an action with a timestamp."""
+
+    action: Action
+    timestamp: Optional[datetime] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class AgentRun:
+    """Represents a sequence of events and objects for one run."""
+
+    run_id: str
+    agent: OntologyObject
+    objects: Dict[str, OntologyObject] = field(default_factory=dict)
+    events: List[Event] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def add_object(self, obj: OntologyObject) -> None:
+        self.objects[obj.object_id] = obj
+
+    def apply_event(self, event: Event) -> None:
+        self.events.append(event)
+        if event.action.target and event.action.target in self.objects:
+            target_obj = self.objects[event.action.target]
+            if event.action.result:
+                target_obj.state.update(event.action.result)
+
+
+@dataclass
+class AgentLog:
+    """Container for multiple runs."""
+
+    runs: List[AgentRun] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)

--- a/agentlogontology/parser.py
+++ b/agentlogontology/parser.py
@@ -1,0 +1,76 @@
+from datetime import datetime
+from typing import Any, Dict, List
+
+from .model import (
+    Action,
+    ActionKind,
+    AgentLog,
+    AgentRun,
+    Event,
+    ObjectKind,
+    OntologyObject,
+)
+
+
+def _parse_timestamp(value: str):
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _map_event_type(event_type: str) -> ActionKind:
+    mapping = {
+        "user_message": ActionKind.OBSERVE,
+        "assistant_response": ActionKind.EXECUTE,
+        "tool_call": ActionKind.EXECUTE,
+        "tool_result": ActionKind.OBSERVE,
+    }
+    return mapping.get(event_type, ActionKind.EXECUTE)
+
+
+def _map_object_kind(event_type: str) -> ObjectKind:
+    mapping = {
+        "user_message": ObjectKind.OBSERVATION,
+        "assistant_response": ObjectKind.THOUGHT,
+        "tool_call": ObjectKind.EXTERNAL_ACTION,
+        "tool_result": ObjectKind.ACTION_RESULT,
+    }
+    return mapping.get(event_type, ObjectKind.EVENT)
+
+
+def from_openai_trace(data: Dict[str, Any]) -> AgentLog:
+    """Convert OpenAI agent-traces JSON dict into AgentLog."""
+    run_id = data.get("trace_id", "unknown")
+    agent_name = data.get("agent_name", "agent")
+
+    agent_obj = OntologyObject(object_id=agent_name, kind=ObjectKind.AGENT)
+    run = AgentRun(run_id=run_id, agent=agent_obj)
+    run.add_object(agent_obj)
+
+    events_data: List[Dict[str, Any]] = data.get("events", [])
+    for idx, e in enumerate(events_data):
+        e_type = e.get("type", "unknown")
+        obj_kind = _map_object_kind(e_type)
+        obj_id = e.get("id", f"obj-{idx}")
+        obj_state = e.get("payload", {})
+        obj = OntologyObject(object_id=obj_id, kind=obj_kind, state=obj_state)
+        run.add_object(obj)
+
+        action_kind = _map_event_type(e_type)
+        action = Action(
+            action_id=f"act-{idx}",
+            kind=action_kind,
+            target=obj_id,
+            params=e.get("payload", {}),
+            result=e.get("payload", {}),
+        )
+        event = Event(
+            action=action,
+            timestamp=_parse_timestamp(e.get("timestamp")),
+            metadata=e.get("metadata", {}),
+        )
+        run.apply_event(event)
+    return AgentLog(runs=[run])

--- a/agentlogontology/serialization.py
+++ b/agentlogontology/serialization.py
@@ -1,0 +1,57 @@
+import json
+from datetime import datetime
+from typing import Any, Dict
+
+from .model import Action, AgentLog, AgentRun, Event, OntologyObject
+
+
+def _datetime_to_iso(dt: datetime) -> str:
+    return dt.isoformat() if dt else None
+
+
+def object_to_dict(obj: OntologyObject) -> Dict[str, Any]:
+    return {
+        "object_id": obj.object_id,
+        "kind": obj.kind.value,
+        "state": obj.state,
+        "metadata": obj.metadata,
+    }
+
+
+def action_to_dict(action: Action) -> Dict[str, Any]:
+    return {
+        "action_id": action.action_id,
+        "kind": action.kind.value,
+        "target": action.target,
+        "params": action.params,
+        "result": action.result,
+    }
+
+
+def event_to_dict(event: Event) -> Dict[str, Any]:
+    return {
+        "timestamp": _datetime_to_iso(event.timestamp),
+        "action": action_to_dict(event.action),
+        "metadata": event.metadata,
+    }
+
+
+def run_to_dict(run: AgentRun) -> Dict[str, Any]:
+    return {
+        "run_id": run.run_id,
+        "agent": object_to_dict(run.agent),
+        "objects": [object_to_dict(o) for o in run.objects.values()],
+        "events": [event_to_dict(e) for e in run.events],
+        "metadata": run.metadata,
+    }
+
+
+def log_to_dict(log: AgentLog) -> Dict[str, Any]:
+    return {
+        "runs": [run_to_dict(r) for r in log.runs],
+        "metadata": log.metadata,
+    }
+
+
+def log_to_json(log: AgentLog) -> str:
+    return json.dumps(log_to_dict(log), indent=2)

--- a/demo.py
+++ b/demo.py
@@ -1,0 +1,71 @@
+import json
+import tkinter as tk
+from tkinter import ttk
+
+from agentlogontology import from_openai_trace
+
+
+class LogViewer(tk.Tk):
+    def __init__(self, log):
+        super().__init__()
+        self.title("Agent Log Viewer")
+        self.log = log
+        self._create_widgets()
+        self._populate()
+
+    def _create_widgets(self):
+        self.tree = ttk.Treeview(self, columns=("action", "object", "kind"), show="headings")
+        self.tree.heading("action", text="Action")
+        self.tree.heading("object", text="Object ID")
+        self.tree.heading("kind", text="Object Kind")
+        self.tree.pack(fill=tk.BOTH, expand=True)
+
+        self.payload_text = tk.Text(self, height=10)
+        self.payload_text.pack(fill=tk.BOTH, expand=True)
+
+        self.save_btn = tk.Button(self, text="Save State", command=self._save)
+        self.save_btn.pack(pady=4)
+
+        self.tree.bind("<<TreeviewSelect>>", self._on_select)
+
+    def _populate(self):
+        run = self.log.runs[0]
+        for idx, event in enumerate(run.events):
+            obj_id = event.action.target or ""
+            obj_kind = run.objects.get(obj_id).kind.value if obj_id in run.objects else ""
+            self.tree.insert("", "end", iid=str(idx), values=(event.action.kind.value, obj_id, obj_kind))
+
+    def _on_select(self, _event):
+        sel = self.tree.selection()
+        if not sel:
+            return
+        idx = int(sel[0])
+        event = self.log.runs[0].events[idx]
+        obj = self.log.runs[0].objects.get(event.action.target)
+        self.payload_text.delete("1.0", tk.END)
+        if obj:
+            self.payload_text.insert(tk.END, json.dumps(obj.state, indent=2))
+
+    def _save(self):
+        sel = self.tree.selection()
+        if not sel:
+            return
+        idx = int(sel[0])
+        try:
+            new_state = json.loads(self.payload_text.get("1.0", tk.END))
+        except json.JSONDecodeError:
+            return
+        run = self.log.runs[0]
+        event = run.events[idx]
+        obj = run.objects.get(event.action.target)
+        if obj:
+            obj.state = new_state
+            self.tree.item(sel[0], values=(event.action.kind.value, obj.object_id, obj.kind.value))
+
+
+if __name__ == "__main__":
+    with open("sample_agent_trace.json") as f:
+        data = json.load(f)
+    log = from_openai_trace(data)
+    viewer = LogViewer(log)
+    viewer.mainloop()

--- a/sample_agent_trace.json
+++ b/sample_agent_trace.json
@@ -1,0 +1,36 @@
+{
+  "trace_id": "sample-run-001",
+  "agent_name": "demo-agent",
+  "events": [
+    {
+      "id": "1",
+      "timestamp": "2024-05-01T12:00:00",
+      "type": "user_message",
+      "payload": {"text": "Hello"}
+    },
+    {
+      "id": "2",
+      "timestamp": "2024-05-01T12:00:01",
+      "type": "assistant_response",
+      "payload": {"text": "Hi, how can I help?"}
+    },
+    {
+      "id": "3",
+      "timestamp": "2024-05-01T12:00:02",
+      "type": "tool_call",
+      "payload": {"tool": "search", "input": "weather in SF"}
+    },
+    {
+      "id": "4",
+      "timestamp": "2024-05-01T12:00:03",
+      "type": "tool_result",
+      "payload": {"result": "sunny"}
+    },
+    {
+      "id": "5",
+      "timestamp": "2024-05-01T12:00:04",
+      "type": "assistant_response",
+      "payload": {"text": "The weather is sunny"}
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- expand ontology with ObjectKind and ActionKind enums
- introduce OntologyObject, Action, updated Event and AgentRun
- rewrite OpenAI trace parser to populate objects and actions
- update serialization helpers and demo GUI
- document the richer design in README

## Testing
- `python -m compileall demo.py agentlogontology`
